### PR TITLE
feat: add output directory support for report exports

### DIFF
--- a/dift/cli.py
+++ b/dift/cli.py
@@ -61,6 +61,11 @@ def main(
         "-o",
         help="Write report to a file.",
     ),
+    output_dir: str | None = typer.Option(
+        None,
+        "--output-dir",
+        help="Directory to save generated reports.",
+    ),
 ) -> None:
     """
     Compare two datasets and instantly detect:
@@ -81,6 +86,7 @@ def main(
       dift old.csv new.csv --key customer_id
       dift old.csv new.csv --report json --output report.json
       dift old.csv new.csv --report csv --output summary.csv
+      dift old.csv new.csv --report csv --output-dir reports/
     """
 
     missing_files: list[str] = []
@@ -100,6 +106,22 @@ def main(
             warning(f"Use examples/{name} or provide a full path.\n")
 
         raise typer.Exit(code=1)
+
+    if output and output_dir:
+        error("Error: Use either --output or --output-dir, not both.")
+        raise typer.Exit(code=1)
+
+    if output_dir:
+        os.makedirs(output_dir, exist_ok=True)
+
+        extension_map = {
+            ReportFormat.json: "json",
+            ReportFormat.csv: "csv",
+        }
+
+        if report in extension_map:
+            extension = extension_map[report]
+            output = os.path.join(output_dir, f"dift_report.{extension}")
 
     try:
         diff_report = compare_datasets(old_dataset, new_dataset, key=key)


### PR DESCRIPTION
## Summary

Adds `--output-dir` support so users can save reports to a directory without manually specifying a full file path.

### Features
- Creates the output directory automatically if it does not exist
- Auto-generates filenames based on report format:
  - `dift_report.json`
  - `dift_report.csv`
- Prevents conflicts when both `--output` and `--output-dir` are used
- Updates Quick Start documentation with `--output-dir` examples

## Why

This improves automation, batch processing, and cleaner report organization by allowing directory-based exports instead of requiring full file paths.

## Testing

Tested manually with:
dift old.csv new.csv --report json --output-dir reports/
dift old.csv new.csv --report csv --output-dir reports/

Verified:
- Directory auto-creation
- Correct filename generation
- JSON/CSV export behavior
- Conflict validation for `--output` + `--output-dir`

## Checklist

- [x] I updated docs where needed
- [ ] I ran tests locally
- [x] I kept the change focused and easy to review