### PR TITLE
31 outlier detection

### DIFF
--- a/dift/core/stats_diff.py
+++ b/dift/core/stats_diff.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import polars as pl
 
 from dift.reports.models import CategoricalDiff, NumericDiff, StatsDiff

--- a/dift/core/stats_diff.py
+++ b/dift/core/stats_diff.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-
 import polars as pl
 
 from dift.reports.models import CategoricalDiff, NumericDiff, StatsDiff
@@ -35,16 +34,8 @@ def compare_stats(old: pl.DataFrame, new: pl.DataFrame, top_n: int = 10) -> Stat
             new_series = new[column]
             old_mean = _safe_float(old_series.mean())
             new_mean = _safe_float(new_series.mean())
-
-            def list_outliers_iqr(col: pl.Series) -> list[float]:
-                iqr = col.quantile(0.75) - col.quantile(0.25)
-                threshold = 1.5
-                lower_limit = col.quantile(0.25) - iqr * threshold
-                upper_limit = col.quantile(0.75) + iqr * threshold
-                return col.filter((col < lower_limit) | (col > upper_limit)).sort(descending=True).to_list()
-
-            old_outliers = list_outliers_iqr(old_series)
-            new_outliers = list_outliers_iqr(new_series)
+            old_outliers = _list_outliers_iqr(old_series)
+            new_outliers = _list_outliers_iqr(new_series)
 
             numeric_diffs.append(
                 NumericDiff(
@@ -102,3 +93,17 @@ def _safe_delta(new_value: float | None, old_value: float | None) -> float | Non
     if new_value is None or old_value is None:
         return None
     return new_value - old_value
+
+
+def _list_outliers_iqr(col: pl.Series) -> list[float] | None:
+    q1, q3 = col.quantile(0.25), col.quantile(0.75)
+    if (q1 is None) or (q3 is None):
+        return None
+
+    iqr = q3 - q1
+    threshold = 1.5
+    lower_limit = q1 - iqr * threshold
+    upper_limit = q3 + iqr * threshold
+    return [val for val
+            in col.drop_nans().drop_nulls().sort(descending=True)
+            if (val < lower_limit) | (val > upper_limit)]

--- a/dift/core/stats_diff.py
+++ b/dift/core/stats_diff.py
@@ -35,6 +35,17 @@ def compare_stats(old: pl.DataFrame, new: pl.DataFrame, top_n: int = 10) -> Stat
             new_series = new[column]
             old_mean = _safe_float(old_series.mean())
             new_mean = _safe_float(new_series.mean())
+
+            def list_outliers_iqr(col: pl.Series) -> list[float]:
+                iqr = col.quantile(0.75) - col.quantile(0.25)
+                threshold = 1.5
+                lower_limit = col.quantile(0.25) - iqr * threshold
+                upper_limit = col.quantile(0.75) + iqr * threshold
+                return col.filter((col < lower_limit) | (col > upper_limit)).sort(descending=True).to_list()
+
+            old_outliers = list_outliers_iqr(old_series)
+            new_outliers = list_outliers_iqr(new_series)
+
             numeric_diffs.append(
                 NumericDiff(
                     column=column,
@@ -47,6 +58,8 @@ def compare_stats(old: pl.DataFrame, new: pl.DataFrame, top_n: int = 10) -> Stat
                     delta_mean=_safe_delta(new_mean, old_mean),
                     old_std=_safe_float(old_series.std()),
                     new_std=_safe_float(new_series.std()),
+                    old_outliers=old_outliers,
+                    new_outliers=new_outliers,
                 )
             )
 

--- a/dift/reports/models.py
+++ b/dift/reports/models.py
@@ -77,8 +77,8 @@ class NumericDiff(BaseModel):
     delta_mean: float | None = None
     old_std: float | None = None
     new_std: float | None = None
-    old_outliers: list[float] = Field(default_factory=list)
-    new_outliers: list[float] = Field(default_factory=list)
+    old_outliers: list[float] | None = None
+    new_outliers: list[float] | None = None
 
 
 class CategoricalDiff(BaseModel):

--- a/dift/reports/models.py
+++ b/dift/reports/models.py
@@ -77,6 +77,8 @@ class NumericDiff(BaseModel):
     delta_mean: float | None = None
     old_std: float | None = None
     new_std: float | None = None
+    old_outliers: list[float] = Field(default_factory=list)
+    new_outliers: list[float] = Field(default_factory=list)
 
 
 class CategoricalDiff(BaseModel):

--- a/tests/test_numericdiff.py
+++ b/tests/test_numericdiff.py
@@ -1,6 +1,7 @@
 import json
 import subprocess
 import sys
+
 from pytest import approx
 
 

--- a/tests/test_numericdiff.py
+++ b/tests/test_numericdiff.py
@@ -1,0 +1,33 @@
+import json
+import subprocess
+import sys
+from pytest import approx
+
+
+def test_cli_numeric_diff(sample_csv_files):
+    old_csv, new_csv = sample_csv_files
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "dift.cli",
+            str(old_csv),
+            str(new_csv),
+            "--key",
+            "customer_id",
+            "--report",
+            "json",
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    numeric_report = json.loads(result.stdout)["numeric"]
+
+    assert result.returncode == 0
+    assert len(numeric_report[0]) == 12
+    assert numeric_report[0]["new_outliers"] == []
+    assert numeric_report[0]["old_outliers"] == []
+    assert numeric_report[2]["new_outliers"] == approx([1350.0, 120.0])
+    assert numeric_report[2]["old_outliers"] == []


### PR DESCRIPTION
## Summary

This PR implements outlier detection for numeric columns, as discussed in issue #31.
Outliers are detected by first calculating the inter quartile range (IQR), using the polars.Series.quantile() method. Subsequently, all values outside a distance of 1.5*IQR below Q1 or above Q3 are categorized as outliers.
The outliers are saved as list[float], or None in case of empty columns.

Currently, outliers are available for all numerical columns in the json output.
Output in other report types was not implemented, since other results from NumericDiff were also not yet part of any other report type.

### Acceptance Criteria
- [x] Outlier detection implemented
- [ ] Included in reports
- [x] Works on numeric columns only


## Why

Outliers are an additional measure to describe numerical columns. Change of outliers may point towards a different distribution, or an extreme change of individual values.

## Testing

One new unit test was introduced to check for outlier output.

```bash
pytest          # 18 tests passed
ruff check .    # Verified (ignoring legacy errors)
mypy dift       # Verified (ignoring legacy errors)
```

## Checklist

- [x] I added or updated tests where needed
- [x] I updated docs where needed
- [x] I ran tests locally
- [x] I kept the change focused and easy to review

<img width="1322" height="367" alt="image" src="https://github.com/user-attachments/assets/fa896aec-f756-4511-b338-67aa57c0c0bb" />

