### PR TITLE
feat: add support for YAML, TOML, and JSON config filesFeature/config file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,8 @@ Dift helps teams catch risky data changes before they cause damage.
 Customize your HTML reports:
 
 ```bash
-dift old.csv new.csv --report html --template clean
-````
+dift old.csv new.csv --report html --template cleans
+```
 
 Available templates:
 
@@ -157,6 +157,28 @@ Auto-generated filenames:
 * `dift_report.csv`
 * `dift_report.xlsx`
 * `dift_report.html`
+
+---
+
+### Configuration System
+
+Dift supports persistent configuration files to make your workflows reproducible and cleaner.
+
+```bash
+dift old.csv new.csv --config dift.yaml
+```
+
+### Supported Formats
+* **YAML** (`.yaml`, `.yml`)
+* **TOML** (`.toml`)
+* **JSON** (`.json`)
+
+### Example Configuration (`dift.yaml`)
+```yaml
+key: "customer_id"
+threshold: 0.05
+report: "html"  
+```
 
 ---
 
@@ -286,6 +308,12 @@ dift examples/old.csv examples/new.csv --key customer_id --report html --output 
 dift examples/old.csv examples/new.csv --key customer_id --report html --template dark --output report.html
 ```
 
+### Compare using a Config File
+
+```bash
+dift examples/old.csv examples/new.csv --config examples/config_sample.yaml
+```
+
 ---
 
 # Example Output
@@ -327,6 +355,10 @@ examples/
 ├── new.json
 ├── old_drift.csv
 └── new_drift.csv
+├── ...
+├── config_sample.yaml
+├── config_sample.toml
+└── config_sample.json
 ```
 
 ---
@@ -464,9 +496,9 @@ ruff check .
 
 #### Config File Support
 
-* YAML configuration support
-* TOML configuration support
-* JSON configuration support
+* [x] YAML configuration support
+* [x] TOML configuration support
+* [x] JSON configuration support
 
 #### Saved Comparison Profiles
 

--- a/dift/cli.py
+++ b/dift/cli.py
@@ -12,6 +12,7 @@ from dift.reports.csv_report import render_csv
 from dift.reports.excel_report import render_excel
 from dift.reports.html_report import render_html
 from dift.reports.json_report import render_json
+from dift.io.config_loader import load_config
 
 app = typer.Typer(
     no_args_is_help=True,
@@ -42,6 +43,10 @@ class ReportFormat(str, Enum):
     excel = "excel"
     html = "html"
 
+# defaults
+DEFAULT_THRESHOLD = 0.1
+DEFAULT_REPORT = ReportFormat.console
+
 
 @app.command()
 def main(
@@ -54,13 +59,13 @@ def main(
         help="Primary key column for row comparison.",
     ),
     threshold: float = typer.Option(
-        0.1,
+        DEFAULT_THRESHOLD,
         "--threshold",
         "-t",
         help="Threshold for numeric drift detection (mean difference).",
     ),
     report: ReportFormat = typer.Option(
-        ReportFormat.console,
+        DEFAULT_REPORT,
         "--report",
         "-r",
         help="Report format.",
@@ -75,6 +80,12 @@ def main(
         None,
         "--output-dir",
         help="Directory to save generated reports.",
+    ),
+    config: str | None = typer.Option(
+        None,
+        "--config",
+        "-c",
+        help="Path to a config file (YAML, TOML, JSON) for reusable settings.",
     ),
     template: str = typer.Option(
         "default",
@@ -106,6 +117,24 @@ def main(
       dift old.csv new.csv --report html --output report.html
       dift old.csv new.csv --report html --template dark --output report.html
     """
+
+    # loading config file
+    config_data = load_config(config) if config else {}
+
+    # Priority: CLI > Config File > Default
+    if key is None:
+        key = config_data.get("key", key)
+
+    if threshold == DEFAULT_THRESHOLD:  
+        threshold = float(config_data.get("threshold", threshold))
+
+    if report == DEFAULT_REPORT:
+        report_str = config_data.get("report")
+        if report_str:
+            try:
+                report = ReportFormat(report_str)
+            except ValueError:
+                warning(f"Invalid report format '{report_str}' in config. Keeping default.")
 
     missing_files: list[str] = []
 

--- a/dift/cli.py
+++ b/dift/cli.py
@@ -7,12 +7,12 @@ import typer
 from rich.console import Console
 
 from dift.core.comparator import compare_datasets
+from dift.io.config_loader import load_config
 from dift.reports.console_report import render_console
 from dift.reports.csv_report import render_csv
 from dift.reports.excel_report import render_excel
 from dift.reports.html_report import render_html
 from dift.reports.json_report import render_json
-from dift.io.config_loader import load_config
 
 app = typer.Typer(
     no_args_is_help=True,
@@ -116,6 +116,7 @@ def main(
       dift old.csv new.csv --report excel --output report.xlsx
       dift old.csv new.csv --report html --output report.html
       dift old.csv new.csv --report html --template dark --output report.html
+      dift old.csv new.csv --config my_config.yaml
     """
 
     # loading config file

--- a/dift/io/__init__.py
+++ b/dift/io/__init__.py
@@ -1,0 +1,1 @@
+from .config_loader import load_config

--- a/dift/io/__init__.py
+++ b/dift/io/__init__.py
@@ -1,1 +1,1 @@
-from .config_loader import load_config
+from .config_loader import load_config as load_config

--- a/dift/io/config_loader.py
+++ b/dift/io/config_loader.py
@@ -1,0 +1,45 @@
+import json
+import pathlib
+
+
+try:
+    import tomllib  
+except ImportError:
+    try:
+        import tomli as tomllib  
+    except ImportError:
+        tomllib = None
+
+def load_config(file_path: str) -> dict:
+    path = pathlib.Path(file_path)
+    if not path.exists():
+        return {}
+
+    suffix = path.suffix.lower()
+
+    try:
+        if suffix == ".json":
+            with open(path, "r") as f:
+                return json.load(f)
+        
+        elif suffix == ".toml":
+            if tomllib:
+                with open(path, "rb") as f:
+                    return tomllib.load(f)
+            else:
+                print("Error: Install 'tomli' to use TOML configs.")
+                return {}
+
+        elif suffix in [".yaml", ".yml"]:
+            try:
+                import yaml
+                with open(path, "r") as f:
+                    return yaml.safe_load(f)
+            except ImportError:
+                print("Error: Install 'PyYAML' to use YAML configs.")
+                return {}
+    except Exception as e:
+        print(f"Failed to parse {suffix} config: {e}")
+        return {}
+
+    return {}

--- a/dift/io/config_loader.py
+++ b/dift/io/config_loader.py
@@ -1,45 +1,47 @@
 import json
 import pathlib
-
+import sys
+from typing import Any, cast
 
 try:
-    import tomllib  
+    import tomllib
 except ImportError:
     try:
-        import tomli as tomllib  
+        # type: ignore[import-not-found, no-redef]
+        import tomli as tomllib
     except ImportError:
         tomllib = None
 
-def load_config(file_path: str) -> dict:
+def load_config(file_path: str) -> dict[str, Any]:
     path = pathlib.Path(file_path)
     if not path.exists():
+        print(f"Warning: Configuration file '{file_path}' not found. Using defaults.", file=sys.stderr)
         return {}
 
     suffix = path.suffix.lower()
 
     try:
         if suffix == ".json":
-            with open(path, "r") as f:
-                return json.load(f)
-        
+            with open(path) as f:
+                return cast(dict[str, Any], json.load(f))        
         elif suffix == ".toml":
             if tomllib:
                 with open(path, "rb") as f:
-                    return tomllib.load(f)
+                    return cast(dict[str, Any], tomllib.load(f))
             else:
-                print("Error: Install 'tomli' to use TOML configs.")
+                print("Error: Install 'tomli' to use TOML configs.", file=sys.stderr)
                 return {}
 
         elif suffix in [".yaml", ".yml"]:
             try:
                 import yaml
-                with open(path, "r") as f:
-                    return yaml.safe_load(f)
+                with open(path) as f:
+                    return cast(dict[str, Any], yaml.safe_load(f))
             except ImportError:
-                print("Error: Install 'PyYAML' to use YAML configs.")
+                print("Error: Install 'PyYAML' to use YAML configs.", file=sys.stderr)
                 return {}
     except Exception as e:
-        print(f"Failed to parse {suffix} config: {e}")
+        print(f"Failed to parse {suffix} config: {e}", file=sys.stderr)
         return {}
 
     return {}

--- a/examples/config_sample.json
+++ b/examples/config_sample.json
@@ -1,0 +1,5 @@
+{
+  "key": "transaction_id",
+  "threshold": 0.2,
+  "report": "csv"
+}

--- a/examples/config_sample.toml
+++ b/examples/config_sample.toml
@@ -1,0 +1,3 @@
+key = "customer_id"
+threshold = 0.1
+report = "json"

--- a/examples/config_sample.ymal
+++ b/examples/config_sample.ymal
@@ -1,0 +1,3 @@
+key: "id"
+threshold: 0.05
+report: "html"

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,8 @@ pyarrow>=15.0.0
 typer>=0.12.0
 rich>=13.7.0
 pydantic>=2.7.0
+tomli>=2.0.1
+PyYAML>=6.0.1
 
 # Dev dependencies
 pytest>=8.0.0

--- a/tests/test_config_file.py
+++ b/tests/test_config_file.py
@@ -1,0 +1,30 @@
+import subprocess
+import sys
+import yaml
+def test_cli_config_file_overrides_defaults(sample_csv_files, tmp_path):
+    old_csv, new_csv = sample_csv_files
+    
+    config_path = tmp_path / "test_config.yaml"
+    
+    config_data = {
+        "threshold": 0.99,
+        "report": "console"
+    }
+    config_path.write_text(yaml.dump(config_data))
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "dift.cli",
+            str(old_csv),
+            str(new_csv),
+            "--config",
+            str(config_path),
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert "Numeric drift" not in result.stdout


### PR DESCRIPTION
## Summary

Added a config_loader to support external configuration files.
I implemented the logic in the main function of the CLI tool.
Priority for the parameters is as follows: CLI > Config > Default.
YAML, TOML and JSON are supported.
Also updated the README and added example config files to the /examples directory. 

## Why

This PR fixes issue #39 and allows users of Dift to use their own config file.

## Testing

I worte 3 example config files and saved them in /examples and then did lots of tests using other example data sets.
Also, I tested ruff, pytest and mypy.

```bash
pytest # all tests passed
ruff check . # all tests passed
mypy dift # all tests regarding my changes passed
```

## Checklist

- [x] I added or updated tests where needed
- [x] I updated docs where needed
- [x] I ran tests locally
- [x] I kept the change focused and easy to review

<img width="1688" height="396" alt="image" src="https://github.com/user-attachments/assets/29ff3ab6-5516-40a9-9536-14c200e53265" />
